### PR TITLE
code blocks require blank line

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -13,6 +13,7 @@ Docker Configuration
 Other commands:
 
 .. code-block:: bash
+
     $ docker --version
     Docker version 1.12.0, build 8eab29e
 

--- a/docs/running_example.rst
+++ b/docs/running_example.rst
@@ -49,6 +49,7 @@ proteins <https://en.wikipedia.org/wiki/PRNP>`__, and we want to find out if the
 Now, let's download and unpack our database, from NCBI
 
     .. code-block:: bash
+
       $ mkdir host-data
       $ docker run -v `pwd`/host-data/:/data/ biocontainers/blast:2.2.31 curl -O ftp://ftp.ncbi.nih.gov/refseq/D_rerio/mRNA_Prot/zebrafish.1.protein.faa.gz
       $ docker run -v `pwd`/host-data/:/data/ biocontainers/blast:2.2.31 gunzip zebrafish.1.protein.faa.gz


### PR DESCRIPTION
Hi, noticed some minor problems in the docs, e.g. on the [Getting started with Docker](https://biocontainers-edu.readthedocs.io/en/latest/getting_started.html) page, the __Other commands__ section is blank. The trivial little change here fixes this for me on a local build of the docs.

Noticed a couple of other similar minor problems, if fixes like this are acceptable I can send those along as well as separate pulls.
